### PR TITLE
Add current date to the footer admin-login page and user-login page

### DIFF
--- a/adminsignup/adminlogin.php
+++ b/adminsignup/adminlogin.php
@@ -90,7 +90,7 @@
     
     <!--Content starts-->
     <div class="content flex">
-    <p>Waste Management system | 2022 |<a href="../login-user.php"> <i class="fa fa-lock" aria-hidden="true"> Login As User</i></a>
+    <p>Waste Management system | <?php echo date('Y'); ?> |<a href="../login-user.php"> <i class="fa fa-lock" aria-hidden="true"> Login As User</i></a>
 
     </p>
     </div>

--- a/adminsignup/connection.php
+++ b/adminsignup/connection.php
@@ -1,3 +1,3 @@
 <?php 
-$con = mysqli_connect('localhost', 'root', '', 'wms');
+$con = mysqli_connect('localhost', 'root', 'Rootroot', 'wms');
 ?>

--- a/connection.php
+++ b/connection.php
@@ -1,3 +1,3 @@
 <?php 
-$con = mysqli_connect('localhost', 'root', '', 'wms');
+$con = mysqli_connect('localhost', 'root', 'Rootroot', 'wms');
 ?>

--- a/login-user.php
+++ b/login-user.php
@@ -91,7 +91,7 @@
     
     <!--Content starts-->
     <div class="content flex">
-    <p>Waste Management system | 2022 | 
+    <p>Waste Management system | <?php echo date('Y'); ?> | 
          <!-- <i class="fa fa-user" aria-hidden="true">Admin</i> -->
          <a href="adminsignup/adminlogin.php"> <i class="fa fa-lock" aria-hidden="true"> Login As Admin</i></a>
          <!-- <i class="fa fa-users" aria-hidden="true"></i> -->


### PR DESCRIPTION
The login-user.php and adminlogin.php pages were displaying the year 2022 in the footer, while it should have shown the current year. I added some PHP code with a built-in function for the display.